### PR TITLE
Relax bytestring version bounds and add hspec-discover

### DIFF
--- a/iso8601-duration.cabal
+++ b/iso8601-duration.cabal
@@ -22,7 +22,7 @@ library
   -- other-modules:
   other-extensions:    ScopedTypeVariables, OverloadedStrings
   build-depends:       base              >= 4.7    && < 5.0
-                     , bytestring        >= 0.10   && < 0.12
+                     , bytestring        >= 0.10   && < 0.13
                      , attoparsec        >= 0.13.1 && < 0.15
                      , time              >= 1.8    && < 1.13
                      , bytestring-lexing >= 0.5    && < 0.6

--- a/iso8601-duration.cabal
+++ b/iso8601-duration.cabal
@@ -34,6 +34,7 @@ library
 
 test-suite spec
   type:                exitcode-stdio-1.0
+  build-tool-depends:  hspec-discover:hspec-discover
   build-depends:       base
                      , bytestring
                      , time


### PR DESCRIPTION
I am creating this pull request so that `iso8601-duration` can be marked as no longer broken in Nixpkgs. It currently fails to build since the Haskell package set in Nixpkgs contains `bytestring` 0.12.2.0, but this package required <0.12.

I also added `hspec-discover` as a proper dependency to the `.cabal` file under the tests section. This should ensure that it gets installed by e.g., `cabal test` and also by the Nix infrastructure that converts Cabal packages into Nix
derivations.
